### PR TITLE
Wrap SQS messages in Records to comply with AWS

### DIFF
--- a/packages/sqs/src/index.js
+++ b/packages/sqs/src/index.js
@@ -27,7 +27,9 @@ module.exports = async ({
       message.body = message.Body
       delete message.Body
     }
-    await trigger(messages)
+    await trigger({
+      Records: [ ...messages ]
+    })
 
     await new Promise((resolve, reject) => {
       sqs.deleteMessageBatch(

--- a/packages/sqs/test/test.js
+++ b/packages/sqs/test/test.js
@@ -10,8 +10,8 @@ const loop = trigger({
   queueUrl: 'http://localhost:9324/queue/test',
   sqs,
   waitTimeSeconds: 0.1,
-  trigger (messages) {
-    return fn(messages)
+  trigger ({ Records }) {
+    return fn(Records)
   },
   onEmpty () {
     return onEmpty()


### PR DESCRIPTION
Hi, 
thank you for this fresh project, it is exactly what we need for our local environment. 

To have the exact same behavior as AWS, sqs messages should be wrapped in an attribute named `Records` as shown here:
https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html

